### PR TITLE
Add configurable RGBW white mixing

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,9 @@ After reboot, a QR code will appear in the web installer. Scan it with:
 | LED Type | WS2812B | Chipset: WS2812B, WS2811, or SK6812 (RGBW) |
 | RGB Order | GRB | Color byte order (try others if colors are wrong) |
 | Max Brightness | 255 | Limits maximum brightness (saves power) |
+| White Mode | accurate | SK6812 RGBW white mixing: accurate, brighter, none, dual, or max |
+| Manual White | 0 | Manual SK6812 white channel level used by none/dual modes |
+| Channel Gains | 255 | Per-channel RGBW calibration gain (0-255) |
 | Device Name | TLED | Name shown in your smart home app |
 | Power-on | restore | Behavior on power up: restore last state, on, or off |
 
@@ -112,10 +115,30 @@ set order <order>       Set RGB order (grb/rgb/brg/rbg/bgr/gbr)
 set brightness <1-255>  Set max brightness
 set name <name>         Set device name
 set poweron <mode>      Power-on behavior (restore/on/off)
+set white_mode <mode>   RGBW white mode (accurate/brighter/none/dual/max)
+set white <0-255>       Manual RGBW white channel level
+set gain_r <0-255>      Red channel gain
+set gain_g <0-255>      Green channel gain
+set gain_b <0-255>      Blue channel gain
+set gain_w <0-255>      White channel gain
 save                    Save configuration and reboot
 reboot                  Restart device
 factory                 Factory reset (erases settings & commissioning)
 ```
+
+### Matching WLED
+
+For SK6812 RGBW strips, TLED defaults to `white_mode accurate`, matching WLED's accurate auto-calculated white behavior by extracting the common RGB component into the white channel. Use `set white_mode brighter` if WLED is set to the brighter auto-calculate mode, `set white_mode none` for RGB plus a fixed manual white level, `set white_mode dual` to use manual white when nonzero and otherwise fall back to brighter mode, or `set white_mode max` to drive white from the strongest RGB channel.
+
+To match an existing WLED installation, compare these settings first:
+
+- **Auto-calculate white channel from RGB:** start with `accurate`, then try `brighter` if the strip is dimmer than WLED.
+- **RGB order:** use `set order grb|rgb|brg|rbg|bgr|gbr` until red, green, and blue match.
+- **Brightness limiter:** match WLED's current limit with `set brightness <1-255>`, or leave both unlimited for calibration.
+- **White, gamma, and correction:** TLED applies only manual white and linear per-channel gains; disable WLED color correction/gamma while matching, or compensate with `gain_r`, `gain_g`, `gain_b`, and `gain_w`.
+- **Matter capability changes:** if a firmware update changes exposed Matter capabilities, remove and re-pair the device in your Matter controller after flashing.
+
+TLED does not currently expose Matter Color Temperature for RGBW white control. The current Matter endpoint is HSV/RGB brightness only, so this change keeps white mixing in firmware configuration instead of adding a new Color Temperature capability.
 
 ## Building from Source
 

--- a/main/app_driver.cpp
+++ b/main/app_driver.cpp
@@ -97,6 +97,12 @@ typedef struct {
     uint8_t gpio_pin;
     uint8_t max_brightness;
     uint8_t rgb_order;      // RGB byte order (tled_rgb_order_t)
+    uint8_t white_mode;     // RGBW white mixing mode (tled_white_mode_t)
+    uint8_t manual_white;
+    uint8_t gain_r;
+    uint8_t gain_g;
+    uint8_t gain_b;
+    uint8_t gain_w;
 
     // Debounce state for HSV updates (issue 7)
     bool hsv_update_pending;
@@ -126,6 +132,13 @@ static light_driver_t s_light_driver = {
     .num_leds = TLED_DEFAULT_NUM_LEDS,
     .gpio_pin = TLED_DEFAULT_GPIO_PIN,
     .max_brightness = TLED_DEFAULT_MAX_BRIGHTNESS,
+    .rgb_order = TLED_DEFAULT_RGB_ORDER,
+    .white_mode = TLED_DEFAULT_WHITE_MODE,
+    .manual_white = TLED_DEFAULT_MANUAL_WHITE,
+    .gain_r = TLED_DEFAULT_CHANNEL_GAIN,
+    .gain_g = TLED_DEFAULT_CHANNEL_GAIN,
+    .gain_b = TLED_DEFAULT_CHANNEL_GAIN,
+    .gain_w = TLED_DEFAULT_CHANNEL_GAIN,
     .hsv_update_pending = false,
     .hsv_update_time = 0,
     .nvs_save_pending = false,
@@ -270,18 +283,6 @@ static void hsv_to_rgb(uint16_t h, uint8_t s, uint8_t v, uint8_t *r, uint8_t *g,
     }
 }
 
-// Extract white component from RGB for RGBW strips
-static void rgb_to_rgbw(uint8_t r, uint8_t g, uint8_t b,
-                         uint8_t *ro, uint8_t *go, uint8_t *bo, uint8_t *wo)
-{
-    uint8_t w = r < g ? r : g;
-    w = w < b ? w : b;
-    *ro = r - w;
-    *go = g - w;
-    *bo = b - w;
-    *wo = w;
-}
-
 // Remap RGB values based on configured byte order.
 // The led_strip component with LED_PIXEL_FORMAT_GRB always transmits bytes as [G, R, B].
 // If the LED expects a different order, we pre-swap the values so the physical bytes match.
@@ -317,15 +318,21 @@ static void remap_rgb_order(uint8_t order, uint8_t r, uint8_t g, uint8_t b,
 static esp_err_t driver_set_pixel(light_driver_t *driver, int index,
                                    uint8_t r, uint8_t g, uint8_t b)
 {
+    if (driver->is_rgbw) {
+        tled_rgbw_color_t rgbw = tled_rgb_to_rgbw(r, g, b,
+                                                  driver->white_mode,
+                                                  driver->manual_white,
+                                                  driver->gain_r,
+                                                  driver->gain_g,
+                                                  driver->gain_b,
+                                                  driver->gain_w);
+        uint8_t mr, mg, mb;
+        remap_rgb_order(driver->rgb_order, rgbw.r, rgbw.g, rgbw.b, &mr, &mg, &mb);
+        return led_strip_set_pixel_rgbw(driver->strip, index, mr, mg, mb, rgbw.w);
+    }
     // Apply RGB order remapping
     uint8_t mr, mg, mb;
     remap_rgb_order(driver->rgb_order, r, g, b, &mr, &mg, &mb);
-
-    if (driver->is_rgbw) {
-        uint8_t ro, go, bo, wo;
-        rgb_to_rgbw(mr, mg, mb, &ro, &go, &bo, &wo);
-        return led_strip_set_pixel_rgbw(driver->strip, index, ro, go, bo, wo);
-    }
     return led_strip_set_pixel(driver->strip, index, mr, mg, mb);
 }
 
@@ -338,20 +345,6 @@ static esp_err_t update_strip_rgb(light_driver_t *driver, uint8_t r, uint8_t g, 
 
     for (int i = 0; i < driver->num_leds; i++) {
         driver_set_pixel(driver, i, r, g, b);
-    }
-
-    return led_strip_refresh(driver->strip);
-}
-
-// Update strip with per-LED RGB array (for chase effects etc)
-static esp_err_t update_strip_array(light_driver_t *driver, uint8_t (*colors)[3])
-{
-    if (driver->strip == NULL) {
-        return ESP_ERR_INVALID_STATE;
-    }
-
-    for (int i = 0; i < driver->num_leds; i++) {
-        driver_set_pixel(driver, i, colors[i][0], colors[i][1], colors[i][2]);
     }
 
     return led_strip_refresh(driver->strip);
@@ -1058,12 +1051,23 @@ app_driver_handle_t app_driver_light_init(void)
     s_light_driver.gpio_pin = config->gpio_pin;
     s_light_driver.max_brightness = config->max_brightness;
     s_light_driver.rgb_order = config->rgb_order;
+    s_light_driver.white_mode = config->white_mode;
+    s_light_driver.manual_white = config->manual_white;
+    s_light_driver.gain_r = config->gain_r;
+    s_light_driver.gain_g = config->gain_g;
+    s_light_driver.gain_b = config->gain_b;
+    s_light_driver.gain_w = config->gain_w;
 
     static const char *rgb_order_names[] = {"GRB", "RGB", "BRG", "RBG", "BGR", "GBR"};
+    static const char *white_mode_names[] = {"accurate", "brighter", "none", "dual", "max"};
     const char *order_name = (s_light_driver.rgb_order <= RGB_ORDER_GBR)
                              ? rgb_order_names[s_light_driver.rgb_order] : "???";
-    ESP_LOGI(TAG, "Initializing LED strip driver on GPIO%d with %d LEDs (max brightness %d, order %s)",
-             s_light_driver.gpio_pin, s_light_driver.num_leds, s_light_driver.max_brightness, order_name);
+    const char *white_mode_name = (s_light_driver.white_mode <= WHITE_MODE_MAX)
+                                  ? white_mode_names[s_light_driver.white_mode] : "???";
+    ESP_LOGI(TAG, "Initializing LED strip driver on GPIO%d with %d LEDs (max brightness %d, order %s, white mode %s, gains %d/%d/%d/%d)",
+             s_light_driver.gpio_pin, s_light_driver.num_leds, s_light_driver.max_brightness,
+             order_name, white_mode_name, s_light_driver.gain_r, s_light_driver.gain_g,
+             s_light_driver.gain_b, s_light_driver.gain_w);
 
     // Create mutex for thread-safe access
     s_light_driver.mutex = xSemaphoreCreateMutex();

--- a/main/app_driver.h
+++ b/main/app_driver.h
@@ -7,6 +7,7 @@
 
 #include <esp_err.h>
 #include <esp_matter.h>
+#include "app_nvs_config.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -16,6 +17,69 @@ extern "C" {
  * @brief Opaque handle for the driver
  */
 typedef void *app_driver_handle_t;
+
+typedef struct {
+    uint8_t r;
+    uint8_t g;
+    uint8_t b;
+    uint8_t w;
+} tled_rgbw_color_t;
+
+/**
+ * @brief Convert logical RGB to RGBW using the configured SK6812 white mode.
+ *
+ * Pure helper for the output pipeline and unit tests. Input and output channels
+ * are 0-255. Gains are applied after white mixing.
+ */
+static inline uint8_t tled_apply_channel_gain(uint8_t value, uint8_t gain)
+{
+    return (uint8_t)(((uint16_t)value * gain) / 255);
+}
+
+static inline tled_rgbw_color_t tled_rgb_to_rgbw(uint8_t r, uint8_t g, uint8_t b,
+                                                 uint8_t white_mode, uint8_t manual_white,
+                                                 uint8_t gain_r, uint8_t gain_g,
+                                                 uint8_t gain_b, uint8_t gain_w)
+{
+    uint8_t min_rgb = r < g ? r : g;
+    min_rgb = min_rgb < b ? min_rgb : b;
+    uint8_t max_rgb = r > g ? r : g;
+    max_rgb = max_rgb > b ? max_rgb : b;
+
+    uint8_t ro = r;
+    uint8_t go = g;
+    uint8_t bo = b;
+    uint8_t wo = 0;
+
+    switch (white_mode) {
+        case WHITE_MODE_BRIGHTER:
+            wo = min_rgb;
+            break;
+        case WHITE_MODE_NONE:
+            wo = manual_white;
+            break;
+        case WHITE_MODE_DUAL:
+            wo = manual_white > 0 ? manual_white : min_rgb;
+            break;
+        case WHITE_MODE_MAX:
+            wo = max_rgb;
+            break;
+        case WHITE_MODE_ACCURATE:
+        default:
+            ro = r - min_rgb;
+            go = g - min_rgb;
+            bo = b - min_rgb;
+            wo = min_rgb;
+            break;
+    }
+
+    tled_rgbw_color_t out;
+    out.r = tled_apply_channel_gain(ro, gain_r);
+    out.g = tled_apply_channel_gain(go, gain_g);
+    out.b = tled_apply_channel_gain(bo, gain_b);
+    out.w = tled_apply_channel_gain(wo, gain_w);
+    return out;
+}
 
 /**
  * @brief Initialize the LED driver (onboard LED for Phase 1)

--- a/main/app_nvs_config.cpp
+++ b/main/app_nvs_config.cpp
@@ -15,6 +15,7 @@ static const char *TAG = "tled_config";
 
 #define NVS_NAMESPACE "tled_cfg"
 #define NVS_KEY_CONFIG "config"
+#define TLED_CONFIG_VERSION_POWER_ON 2
 
 // Valid GPIO pins for ESP32-C6 LED data output
 // Avoiding: 9 (boot button), 12-13 (USB), 15 (onboard LED)
@@ -35,10 +36,43 @@ static void set_defaults(tled_config_t *config)
     config->chipset = TLED_DEFAULT_CHIPSET;
     config->max_brightness = TLED_DEFAULT_MAX_BRIGHTNESS;
     config->power_on_behavior = TLED_DEFAULT_POWER_ON;
+    config->white_mode = TLED_DEFAULT_WHITE_MODE;
+    config->manual_white = TLED_DEFAULT_MANUAL_WHITE;
+    config->gain_r = TLED_DEFAULT_CHANNEL_GAIN;
+    config->gain_g = TLED_DEFAULT_CHANNEL_GAIN;
+    config->gain_b = TLED_DEFAULT_CHANNEL_GAIN;
+    config->gain_w = TLED_DEFAULT_CHANNEL_GAIN;
     strncpy(config->device_name, TLED_DEFAULT_DEVICE_NAME, sizeof(config->device_name) - 1);
     config->device_name[sizeof(config->device_name) - 1] = '\0';
     config->config_version = TLED_CONFIG_VERSION;
     config->configured = false;
+}
+
+typedef struct {
+    uint16_t num_leds;
+    uint8_t gpio_pin;
+    uint8_t rgb_order;
+    uint8_t chipset;
+    uint8_t max_brightness;
+    uint8_t power_on_behavior;
+    char device_name[32];
+    uint8_t config_version;
+    bool configured;
+} tled_config_v2_t;
+
+static void migrate_v2_config(const tled_config_v2_t *old_config, tled_config_t *new_config)
+{
+    set_defaults(new_config);
+    new_config->num_leds = old_config->num_leds;
+    new_config->gpio_pin = old_config->gpio_pin;
+    new_config->rgb_order = old_config->rgb_order;
+    new_config->chipset = old_config->chipset;
+    new_config->max_brightness = old_config->max_brightness;
+    new_config->power_on_behavior = old_config->power_on_behavior;
+    strncpy(new_config->device_name, old_config->device_name, sizeof(new_config->device_name) - 1);
+    new_config->device_name[sizeof(new_config->device_name) - 1] = '\0';
+    new_config->configured = old_config->configured;
+    new_config->config_version = TLED_CONFIG_VERSION;
 }
 
 // Validate configuration
@@ -71,6 +105,12 @@ static bool validate_config(const tled_config_t *config)
     // Check power-on behavior
     if (config->power_on_behavior > POWER_ON_OFF) {
         ESP_LOGW(TAG, "Invalid power-on behavior: %d", config->power_on_behavior);
+        return false;
+    }
+
+    // Check RGBW white mode
+    if (config->white_mode > WHITE_MODE_MAX) {
+        ESP_LOGW(TAG, "Invalid white mode: %d", config->white_mode);
         return false;
     }
 
@@ -107,26 +147,46 @@ esp_err_t tled_config_init(void)
     esp_err_t err = nvs_open(NVS_NAMESPACE, NVS_READONLY, &handle);
 
     if (err == ESP_OK) {
-        size_t size = sizeof(tled_config_t);
-        err = nvs_get_blob(handle, NVS_KEY_CONFIG, &s_config, &size);
-        nvs_close(handle);
+        size_t size = 0;
+        err = nvs_get_blob(handle, NVS_KEY_CONFIG, NULL, &size);
 
         if (err == ESP_OK && size == sizeof(tled_config_t)) {
+            err = nvs_get_blob(handle, NVS_KEY_CONFIG, &s_config, &size);
             // Validate loaded config
-            if (validate_config(&s_config)) {
-                ESP_LOGI(TAG, "Config loaded: %d LEDs, GPIO%d, order=%d, chipset=%d, max_bri=%d, name=%s",
+            if (err == ESP_OK && validate_config(&s_config)) {
+                nvs_close(handle);
+                ESP_LOGI(TAG, "Config loaded: %d LEDs, GPIO%d, order=%d, chipset=%d, max_bri=%d, white_mode=%d, gains=%d/%d/%d/%d, name=%s",
                          s_config.num_leds, s_config.gpio_pin, s_config.rgb_order,
-                         s_config.chipset, s_config.max_brightness, s_config.device_name);
+                         s_config.chipset, s_config.max_brightness, s_config.white_mode,
+                         s_config.gain_r, s_config.gain_g, s_config.gain_b, s_config.gain_w,
+                         s_config.device_name);
                 s_initialized = true;
                 return ESP_OK;
             } else {
                 ESP_LOGW(TAG, "Loaded config invalid, using defaults");
                 set_defaults(&s_config);
             }
+        } else if (err == ESP_OK && size == sizeof(tled_config_v2_t)) {
+            tled_config_v2_t old_config;
+            err = nvs_get_blob(handle, NVS_KEY_CONFIG, &old_config, &size);
+            if (err == ESP_OK && old_config.config_version == TLED_CONFIG_VERSION_POWER_ON) {
+                migrate_v2_config(&old_config, &s_config);
+                if (validate_config(&s_config)) {
+                    nvs_close(handle);
+                    ESP_LOGI(TAG, "Migrated v2 config: %d LEDs, GPIO%d, order=%d, chipset=%d, max_bri=%d, name=%s",
+                             s_config.num_leds, s_config.gpio_pin, s_config.rgb_order,
+                             s_config.chipset, s_config.max_brightness, s_config.device_name);
+                    s_initialized = true;
+                    return ESP_OK;
+                }
+            }
+            ESP_LOGW(TAG, "Failed to migrate config blob, using defaults");
+            set_defaults(&s_config);
         } else {
             ESP_LOGW(TAG, "Failed to load config blob, using defaults");
             set_defaults(&s_config);
         }
+        nvs_close(handle);
     } else {
         ESP_LOGI(TAG, "No config in NVS (first boot), using defaults");
     }

--- a/main/app_nvs_config.h
+++ b/main/app_nvs_config.h
@@ -34,6 +34,15 @@ typedef enum {
     POWER_ON_OFF = 2,       // Always stay off
 } tled_power_on_t;
 
+// SK6812 RGBW white-channel mixing mode
+typedef enum {
+    WHITE_MODE_ACCURATE = 0, // Extract common RGB into W, preserving color accuracy
+    WHITE_MODE_BRIGHTER = 1, // Add common RGB to W while keeping RGB channels
+    WHITE_MODE_NONE = 2,     // No automatic white extraction, manual W only
+    WHITE_MODE_DUAL = 3,     // Manual W when set, otherwise brighter mode
+    WHITE_MODE_MAX = 4,      // Drive W from the strongest RGB channel
+} tled_white_mode_t;
+
 // Configuration structure
 typedef struct {
     uint16_t num_leds;          // Number of LEDs (1-1000)
@@ -42,6 +51,12 @@ typedef struct {
     uint8_t chipset;            // LED chipset (tled_chipset_t)
     uint8_t max_brightness;     // Max brightness limit (0-255)
     uint8_t power_on_behavior;  // Power-on behavior (tled_power_on_t)
+    uint8_t white_mode;         // RGBW white mixing mode (tled_white_mode_t)
+    uint8_t manual_white;       // Manual white channel level (0-255)
+    uint8_t gain_r;             // Red channel gain (0-255)
+    uint8_t gain_g;             // Green channel gain (0-255)
+    uint8_t gain_b;             // Blue channel gain (0-255)
+    uint8_t gain_w;             // White channel gain (0-255)
     char device_name[32];       // Custom device name
     uint8_t config_version;     // Config version for migration
     bool configured;            // True if config has been set
@@ -84,7 +99,10 @@ typedef struct {
 
 #define TLED_DEFAULT_DEVICE_NAME    "TLED"
 #define TLED_DEFAULT_POWER_ON       POWER_ON_RESTORE
-#define TLED_CONFIG_VERSION         2  // Bumped for power_on_behavior field
+#define TLED_DEFAULT_WHITE_MODE     WHITE_MODE_ACCURATE
+#define TLED_DEFAULT_MANUAL_WHITE   0
+#define TLED_DEFAULT_CHANNEL_GAIN   255
+#define TLED_CONFIG_VERSION         3  // Bumped for RGBW white mixing and gains
 
 /**
  * @brief Initialize the config module
@@ -158,4 +176,3 @@ bool tled_config_validate_gpio(uint8_t gpio_pin);
 
 // Alias for reset function
 #define tled_config_reset() tled_config_reset_to_defaults()
-

--- a/main/app_serial_config.cpp
+++ b/main/app_serial_config.cpp
@@ -31,6 +31,7 @@ static void process_command(const char *cmd);
 static void print_help(void);
 static void print_config(void);
 static void handle_set_command(const char *param, const char *value);
+static const char *white_mode_to_str(uint8_t mode);
 
 static void serial_write(const char *str) {
     usb_serial_jtag_write_bytes((const uint8_t *)str, strlen(str), pdMS_TO_TICKS(100));
@@ -170,6 +171,12 @@ static void print_help(void) {
     serial_write("  set order <o>     - Set RGB order: grb, rgb, brg, rbg, bgr, gbr\r\n");
     serial_write("  set name <name>   - Set device name\r\n");
     serial_write("  set poweron <m>   - Power-on behavior: restore, on, off\r\n");
+    serial_write("  set white_mode <m> - RGBW white mode: accurate, brighter, none, dual, max\r\n");
+    serial_write("  set white <n>     - Manual RGBW white level (0-255)\r\n");
+    serial_write("  set gain_r <n>    - Red channel gain (0-255)\r\n");
+    serial_write("  set gain_g <n>    - Green channel gain (0-255)\r\n");
+    serial_write("  set gain_b <n>    - Blue channel gain (0-255)\r\n");
+    serial_write("  set gain_w <n>    - White channel gain (0-255)\r\n");
     serial_write("  save              - Save config and reboot\r\n");
     serial_write("  reboot            - Reboot without saving\r\n");
     serial_write("  factory           - Reset to factory defaults\r\n");
@@ -210,8 +217,35 @@ static void print_config(void) {
     serial_printf("  type       = %s\r\n", type_str);
     serial_printf("  order      = %s\r\n", order_str);
     serial_printf("  poweron    = %s\r\n", poweron_str);
+    serial_printf("  white_mode = %s\r\n", white_mode_to_str(cfg->white_mode));
+    serial_printf("  white      = %d\r\n", cfg->manual_white);
+    serial_printf("  gain_r     = %d\r\n", cfg->gain_r);
+    serial_printf("  gain_g     = %d\r\n", cfg->gain_g);
+    serial_printf("  gain_b     = %d\r\n", cfg->gain_b);
+    serial_printf("  gain_w     = %d\r\n", cfg->gain_w);
     serial_printf("  name       = %s\r\n", cfg->device_name);
     serial_write("\r\n");
+}
+
+static const char *white_mode_to_str(uint8_t mode) {
+    switch (mode) {
+        case WHITE_MODE_ACCURATE: return "accurate";
+        case WHITE_MODE_BRIGHTER: return "brighter";
+        case WHITE_MODE_NONE: return "none";
+        case WHITE_MODE_DUAL: return "dual";
+        case WHITE_MODE_MAX: return "max";
+        default: return "unknown";
+    }
+}
+
+static bool parse_u8_value(const char *value, uint8_t *out) {
+    char *end = NULL;
+    long parsed = strtol(value, &end, 10);
+    if (end == value || *end != '\0' || parsed < 0 || parsed > 255) {
+        return false;
+    }
+    *out = (uint8_t)parsed;
+    return true;
 }
 
 static void handle_set_command(const char *param, const char *value) {
@@ -299,6 +333,50 @@ static void handle_set_command(const char *param, const char *value) {
         } else {
             serial_write("Error: poweron must be restore, on, or off\r\n");
         }
+    }
+    else if (strcmp(param, "white_mode") == 0) {
+        if (strcmp(value, "accurate") == 0) {
+            cfg->white_mode = WHITE_MODE_ACCURATE;
+            serial_write("Set white_mode = accurate\r\n");
+        } else if (strcmp(value, "brighter") == 0) {
+            cfg->white_mode = WHITE_MODE_BRIGHTER;
+            serial_write("Set white_mode = brighter\r\n");
+        } else if (strcmp(value, "none") == 0) {
+            cfg->white_mode = WHITE_MODE_NONE;
+            serial_write("Set white_mode = none\r\n");
+        } else if (strcmp(value, "dual") == 0) {
+            cfg->white_mode = WHITE_MODE_DUAL;
+            serial_write("Set white_mode = dual\r\n");
+        } else if (strcmp(value, "max") == 0) {
+            cfg->white_mode = WHITE_MODE_MAX;
+            serial_write("Set white_mode = max\r\n");
+        } else {
+            serial_write("Error: white_mode must be accurate, brighter, none, dual, or max\r\n");
+        }
+    }
+    else if (strcmp(param, "white") == 0 ||
+             strcmp(param, "gain_r") == 0 ||
+             strcmp(param, "gain_g") == 0 ||
+             strcmp(param, "gain_b") == 0 ||
+             strcmp(param, "gain_w") == 0) {
+        uint8_t n;
+        if (!parse_u8_value(value, &n)) {
+            serial_printf("Error: %s must be 0-255\r\n", param);
+            return;
+        }
+
+        if (strcmp(param, "white") == 0) {
+            cfg->manual_white = n;
+        } else if (strcmp(param, "gain_r") == 0) {
+            cfg->gain_r = n;
+        } else if (strcmp(param, "gain_g") == 0) {
+            cfg->gain_g = n;
+        } else if (strcmp(param, "gain_b") == 0) {
+            cfg->gain_b = n;
+        } else {
+            cfg->gain_w = n;
+        }
+        serial_printf("Set %s = %d\r\n", param, n);
     }
     else {
         serial_printf("Unknown parameter: %s\r\n", param);

--- a/test/test_app_driver.cpp
+++ b/test/test_app_driver.cpp
@@ -7,6 +7,7 @@
 
 #include <unity.h>
 #include <esp_err.h>
+#include "app_driver.h"
 
 // Note: Full driver tests require hardware. These are placeholder tests
 // that define the expected interface and behavior.
@@ -55,4 +56,102 @@ TEST_CASE("app_driver_button_init returns valid handle", "[driver]")
     // app_driver_handle_t handle = app_driver_button_init();
     // TEST_ASSERT_NOT_NULL(handle);
     TEST_PASS();
+}
+
+TEST_CASE("RGBW accurate mode extracts common white", "[driver][rgbw]")
+{
+    tled_rgbw_color_t white = tled_rgb_to_rgbw(128, 128, 128, WHITE_MODE_ACCURATE,
+                                               0, 255, 255, 255, 255);
+    TEST_ASSERT_EQUAL_UINT8(0, white.r);
+    TEST_ASSERT_EQUAL_UINT8(0, white.g);
+    TEST_ASSERT_EQUAL_UINT8(0, white.b);
+    TEST_ASSERT_EQUAL_UINT8(128, white.w);
+
+    tled_rgbw_color_t red = tled_rgb_to_rgbw(255, 0, 0, WHITE_MODE_ACCURATE,
+                                             0, 255, 255, 255, 255);
+    TEST_ASSERT_EQUAL_UINT8(255, red.r);
+    TEST_ASSERT_EQUAL_UINT8(0, red.g);
+    TEST_ASSERT_EQUAL_UINT8(0, red.b);
+    TEST_ASSERT_EQUAL_UINT8(0, red.w);
+
+    tled_rgbw_color_t green = tled_rgb_to_rgbw(0, 255, 0, WHITE_MODE_ACCURATE,
+                                               0, 255, 255, 255, 255);
+    TEST_ASSERT_EQUAL_UINT8(0, green.r);
+    TEST_ASSERT_EQUAL_UINT8(255, green.g);
+    TEST_ASSERT_EQUAL_UINT8(0, green.b);
+    TEST_ASSERT_EQUAL_UINT8(0, green.w);
+
+    tled_rgbw_color_t blue = tled_rgb_to_rgbw(0, 0, 255, WHITE_MODE_ACCURATE,
+                                              0, 255, 255, 255, 255);
+    TEST_ASSERT_EQUAL_UINT8(0, blue.r);
+    TEST_ASSERT_EQUAL_UINT8(0, blue.g);
+    TEST_ASSERT_EQUAL_UINT8(255, blue.b);
+    TEST_ASSERT_EQUAL_UINT8(0, blue.w);
+}
+
+TEST_CASE("RGBW accurate mode preserves pastel chroma", "[driver][rgbw]")
+{
+    tled_rgbw_color_t color = tled_rgb_to_rgbw(200, 160, 120, WHITE_MODE_ACCURATE,
+                                               0, 255, 255, 255, 255);
+    TEST_ASSERT_EQUAL_UINT8(80, color.r);
+    TEST_ASSERT_EQUAL_UINT8(40, color.g);
+    TEST_ASSERT_EQUAL_UINT8(0, color.b);
+    TEST_ASSERT_EQUAL_UINT8(120, color.w);
+}
+
+TEST_CASE("RGBW none mode uses manual white without RGB extraction", "[driver][rgbw]")
+{
+    tled_rgbw_color_t color = tled_rgb_to_rgbw(20, 40, 60, WHITE_MODE_NONE,
+                                               77, 255, 255, 255, 255);
+    TEST_ASSERT_EQUAL_UINT8(20, color.r);
+    TEST_ASSERT_EQUAL_UINT8(40, color.g);
+    TEST_ASSERT_EQUAL_UINT8(60, color.b);
+    TEST_ASSERT_EQUAL_UINT8(77, color.w);
+}
+
+TEST_CASE("RGBW brighter and max modes keep RGB unchanged", "[driver][rgbw]")
+{
+    tled_rgbw_color_t brighter = tled_rgb_to_rgbw(20, 40, 60, WHITE_MODE_BRIGHTER,
+                                                  0, 255, 255, 255, 255);
+    TEST_ASSERT_EQUAL_UINT8(20, brighter.r);
+    TEST_ASSERT_EQUAL_UINT8(40, brighter.g);
+    TEST_ASSERT_EQUAL_UINT8(60, brighter.b);
+    TEST_ASSERT_EQUAL_UINT8(20, brighter.w);
+
+    tled_rgbw_color_t max = tled_rgb_to_rgbw(20, 40, 60, WHITE_MODE_MAX,
+                                             0, 255, 255, 255, 255);
+    TEST_ASSERT_EQUAL_UINT8(20, max.r);
+    TEST_ASSERT_EQUAL_UINT8(40, max.g);
+    TEST_ASSERT_EQUAL_UINT8(60, max.b);
+    TEST_ASSERT_EQUAL_UINT8(60, max.w);
+}
+
+TEST_CASE("RGBW dual mode uses manual white when set", "[driver][rgbw]")
+{
+    tled_rgbw_color_t color = tled_rgb_to_rgbw(30, 50, 70, WHITE_MODE_DUAL,
+                                               25, 255, 255, 255, 255);
+    TEST_ASSERT_EQUAL_UINT8(30, color.r);
+    TEST_ASSERT_EQUAL_UINT8(50, color.g);
+    TEST_ASSERT_EQUAL_UINT8(70, color.b);
+    TEST_ASSERT_EQUAL_UINT8(25, color.w);
+}
+
+TEST_CASE("RGBW dual mode falls back to brighter when manual white is zero", "[driver][rgbw]")
+{
+    tled_rgbw_color_t color = tled_rgb_to_rgbw(30, 50, 70, WHITE_MODE_DUAL,
+                                               0, 255, 255, 255, 255);
+    TEST_ASSERT_EQUAL_UINT8(30, color.r);
+    TEST_ASSERT_EQUAL_UINT8(50, color.g);
+    TEST_ASSERT_EQUAL_UINT8(70, color.b);
+    TEST_ASSERT_EQUAL_UINT8(30, color.w);
+}
+
+TEST_CASE("RGBW gains scale converted channels", "[driver][rgbw]")
+{
+    tled_rgbw_color_t color = tled_rgb_to_rgbw(100, 80, 60, WHITE_MODE_ACCURATE,
+                                               0, 255, 128, 0, 64);
+    TEST_ASSERT_EQUAL_UINT8(40, color.r);
+    TEST_ASSERT_EQUAL_UINT8(10, color.g);
+    TEST_ASSERT_EQUAL_UINT8(0, color.b);
+    TEST_ASSERT_EQUAL_UINT8(15, color.w);
 }


### PR DESCRIPTION
## Summary
- add configurable SK6812 RGBW white mixing modes matching WLED options: accurate, brighter, none, dual, and max
- add manual white and per-channel RGBW gain settings persisted in NVS
- add serial config commands and README guidance for matching WLED
- add unit coverage for RGBW conversion behavior

## Verification
- built successfully with ESP-IDF v5.4.2 and ESP-Matter
- verified generated firmware: build/tled.bin